### PR TITLE
fix | sprint2 | FRB-54 | zoneId, equipId같은 알람의 경우 제일 최신것만 표시되도록 수정 + alarm객체에 dangerLevel 필드 추가

### DIFF
--- a/src/contexts/ToastProvider.tsx
+++ b/src/contexts/ToastProvider.tsx
@@ -22,7 +22,7 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const showToast = (alarm: AlarmEvent) => {
     if (alarm.riskLevel == "CRITICAL" || alarm.riskLevel == "WARNING") {
-      setToasts((prev) => [...prev, alarm]);
+      setToasts((prev) => [alarm, ...prev]);
 
       setTimeout(() => {
         setToasts((prev) => prev.filter((t) => t.eventId !== alarm.eventId));
@@ -81,17 +81,27 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
       {ReactDOM.createPortal(
         <div className="fixed top-4 right-4 space-y-2 z-50 pointer-events-none">
           <div className="absolute top-4 right-4 space-y-2 pointer-events-auto">
-            {toasts.map((toast) => (
-              <div
-                key={toast.eventId}
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleToastClick(toast);
-                }}
-                className={`px-4 py-3 rounded shadow-md cursor-pointer transition-all animate-fade-in ${getColor(
-                  toast.riskLevel
-                )}`}
+            {toasts
+              .reduce<AlarmEvent[]>((uniqueToasts, toast) => {
+                const isDuplicate = uniqueToasts.some(
+                  (t: AlarmEvent) => t.zoneId === toast.zoneId && t.equipId === toast.equipId
+                );
+                if (!isDuplicate) {
+                  uniqueToasts.push(toast);
+                }
+                return uniqueToasts;
+              }, [])
+              .map((toast) => (
+                <div
+                  key={toast.eventId}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    handleToastClick(toast);
+                  }}
+                  className={`px-4 py-3 rounded shadow-md cursor-pointer transition-all animate-fade-in ${getColor(
+                    toast.riskLevel
+                  )}`}
               >
                 <MonitorIcon
                   abnormal_sensor={toast.sensorType}

--- a/src/types/Alarm.ts
+++ b/src/types/Alarm.ts
@@ -11,6 +11,7 @@ export interface AlarmEvent {
   time: string;
   messageBody: string;
   source: string;
+  zoneName: string;
 }
 
 export interface AbnormalLogDto {
@@ -18,6 +19,7 @@ export interface AbnormalLogDto {
   targetType: "Sensor" | "Worker" | "Equip"; // LogType enum에 따라 수정 필요
   targetId: string;
   abnormalType: string;
+  dangerLevel: number;
   abnVal: number;
   detectedAt: string; // ISO 문자열 (e.g., "2025-05-10T12:00:00Z")
   zoneId: string;


### PR DESCRIPTION
…Alarm 객체에서 Dangerlevel도 받아오도록 수정 | 김우영

## 📌 PR 제목
화면 오른쪽 하단 알림 겹치도록 수정(최신것만 표시되도록)

---

## ✨ 변경 사항
- 주요 변경 사항을 bullet 형식으로 정리해주세요.
- 예: 로그인 UI 추가, JWT 인증 로직 구현 등

---

## 📸 스크린샷 (선택)
| 변경 전 | 변경 후 |
|--------|--------|
| (이미지) | (이미지) |

---

## ✅ 체크리스트
- [ ] 코드에 불필요한 부분은 없는가?
- [ ] 기능이 정상 동작하는가?
- [ ] 의존성은 문제가 없는가?
- [ ] 커밋 메시지는 명확한가?

---

## 📎 관련 이슈
- 관련된 이슈 번호: #123

---

## 💬 추가 설명
- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요.
