### PR TITLE
fix | sprint3 | FRB-201 | unread-count 조회하도록 수정 | 김우영

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -19,23 +19,19 @@ export default function Login() {
   }, []);
 
   const handleLogin = () => {
-    const response = axiosInstance
-      .post("/api/auth/login", {
-        username: userId,
-        password: userPassword,
-      })
-      .then((res) => {
-        console.log("로그인 성공");
-        console.log(res.data);
-        localStorage.setItem("accessToken", res.data.accessToken);
-        localStorage.setItem("userId", userId);
-        nav(`/`);
-      })
-      .catch((e) => {
-        console.log("로그인 실패");
-        console.log(e);
-        alert("아이디 또는 비밀번호가 잘못되었습니다.");
-      });
+    const response = axiosInstance.post("/api/auth/login", {
+      username: userId,
+      password: userPassword,
+    }).then((res) => {
+      console.log("로그인 성공");
+      console.log(res.data);
+      axiosInstance.get("/api/abnormal/unread-count")
+      nav("/");
+    }).catch((e) => {
+      console.log("로그인 실패");
+      console.log(e);
+      alert("아이디 또는 비밀번호가 잘못되었습니다.");
+    });
     console.log(response);
   };
   return (


### PR DESCRIPTION
## 📌 PR 제목
unread-count 조회하도록 수정

---

## ✨ 변경 사항
- (원인) sidebar가 라우터의 최상단에 항상 있어 렌더링이 1번밖에 안됨
- -> (해결) 로그인 시 unread-count를 호출하도록 변경
- (원인) 기존에는 우측 하단의 알람이 올때마다 좌측 하단의 숫자를 갱신해주었는데, 우측 하단의 알림 숫자가 현저히 줄어들어 숫자 갱신이 안되는 오류가 발견됨.
- -> (해결) 읽음 처리할때 웹소켓에서 unread-count를 전달하지 않아 왼쪽 하단 숫자가 갱신이 안됨 -> 읽음 처리할때마다 websocket 주도록 변경 
---

## 📸 스크린샷 (선택)
| 변경 전 | 변경 후 |
|--------|--------|
| (이미지) | (이미지) |

---

## ✅ 체크리스트
- [ ] 코드에 불필요한 부분은 없는가?
- [ ] 기능이 정상 동작하는가?
- [ ] 의존성은 문제가 없는가?
- [ ] 커밋 메시지는 명확한가?

---

## 📎 관련 이슈
- 관련된 이슈 번호: #123

---

## 💬 추가 설명
- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요.
