### PR TITLE
fix | sprint2 | FRB-77 | 리포트 로딩 오류 수정

### DIFF
--- a/src/components/MainBox.jsx
+++ b/src/components/MainBox.jsx
@@ -113,7 +113,7 @@ export default function MainBox({ isSidebarOpen }) {
 
   useEffect(() => {
     axiosInstance
-      .get()
+      .get(`/api/abnormal/report`)
       .then((res) => {
         console.log("요약리포트 로딩 완료", res.data.data);
         setReport(res.data.data);
@@ -172,9 +172,10 @@ export default function MainBox({ isSidebarOpen }) {
           반영 기간: {formatted(lastMonth)} ~ {formatted(now)}
         </p>
         <div className="donut-wrapper">
-          {report.map((r, i) => {
-            return <Donut report={r} color={getColor(r.grade)} key={i} />;
-          })}
+          {report &&
+            report.map((r, i) => {
+              return <Donut report={r} color={getColor(r.grade)} key={i} />;
+            })}
         </div>
       </div>
     </>


### PR DESCRIPTION

## 📌 PR 제목
[fix] 리포트 로딩 오류 수정
---

## ✨ 변경 사항
- 이게 바로 그 유명한 핫픽스?!
  - 오류 원인(1): 비어있는 URI로 요청했을 때 클라우드에서는 catch로 안 넘어가네요??? 왜지???
  - 오류 원인(2): 비어있는 배열을 받았을 때의 예외처리가 되지 않음

---


## 💬 추가 설명
- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요.
