### PR TITLE
[feat] 작업자 등록/수정 분리

### DIFF
--- a/src/components/LogTable.jsx
+++ b/src/components/LogTable.jsx
@@ -1,13 +1,12 @@
 import { useRef } from "react";
 
-export default function LogTable({ logs, onScrollEnd }) {
+export default function LogTable({ logs, onScrollEnd, scrollBoxRef }) {
   const handleScroll = (e) => {
     const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
     if (scrollTop + clientHeight >= scrollHeight - 10) {
       onScrollEnd();
     }
   };
-  const scrollBoxRef = useRef(null);
   return (
     <div
       ref={scrollBoxRef}

--- a/src/components/MainBox.jsx
+++ b/src/components/MainBox.jsx
@@ -88,9 +88,7 @@ function Donut({ report, color }) {
         </PieChart>
       </ResponsiveContainer>
       <p>
-        발생 건수 {report.warnCnt + report.dangerCnt}건 (위험:{" "}
-        {report.dangerCnt}
-        건)
+        경고/위험 발생 <strong>{report.warnCnt + report.dangerCnt}건</strong>
       </p>
     </div>
   );

--- a/src/components/MainBox.jsx
+++ b/src/components/MainBox.jsx
@@ -118,7 +118,7 @@ export default function MainBox({ isSidebarOpen }) {
       .get(`/api/abnormal/report`)
       .then((res) => {
         console.log("요약리포트 로딩 완료", res.data.data);
-        setReport(res.data.data);
+        setReport(res.data.data.abnormalInfos);
       })
       .catch((e) => {
         console.log("요약리포트 로딩 실패", e);
@@ -172,7 +172,7 @@ export default function MainBox({ isSidebarOpen }) {
         </p>
         <div className="donut-wrapper">
           {report &&
-            report.map((r, i) => {
+            report?.map((r, i) => {
               return <Donut report={r} color={getColor(r.grade)} key={i} />;
             })}
         </div>

--- a/src/components/WorkerTable.jsx
+++ b/src/components/WorkerTable.jsx
@@ -11,17 +11,9 @@ const statusKor = (status) => {
   }
 };
 
-const formattedPhoneNumber = (phoneNumber) => {
-  if (phoneNumber.startsWith("+82")) {
-    return phoneNumber;
-  } else {
-    return "+82" + phoneNumber.slice(-10);
-  }
-};
-
 export default function WorkerTable({
   worker_list,
-  isDetail = false, // "현재 위치" 포함 여부 (Y=false, N=true)
+  isDetail = false,
   selectWorker,
   openModal,
   isManager = false,
@@ -113,7 +105,7 @@ export default function WorkerTable({
             </th>
           </tr>
         )}
-        <div style={{ width: "100%", height: "100%", overflowY: "scroll" }}>
+        <div style={{ width: "100%", height: "100%", overflowY: "auto" }}>
           <table className="worker-table">
             <thead>
               <tr className="table-header">
@@ -124,7 +116,7 @@ export default function WorkerTable({
                 <th className="contact-row">이메일</th>
                 <th className="contact-row">전화번호</th>
                 <th style={{ width: "5%" }}>호출</th>
-                <th style={{ width: "5%" }}>상세정보</th>
+                <th style={{ width: "5%" }}>정보 수정</th>
               </tr>
             </thead>
             <tbody>
@@ -146,9 +138,7 @@ export default function WorkerTable({
                       <td>{worker.name}</td>
                       {!isDetail && <td>{worker.currentZoneName}</td>}
                       <td className="contact-row">{worker.email}</td>
-                      <td className="contact-row">
-                        {formattedPhoneNumber(worker.phoneNumber)}
-                      </td>
+                      <td className="contact-row">{worker.phoneNumber}</td>
                       <td
                         style={{ fontSize: "1.2rem", cursor: "pointer" }}
                         onClick={() => directCall(worker)}
@@ -165,7 +155,7 @@ export default function WorkerTable({
                           openModal(true);
                         }}
                       >
-                        조회
+                        수정
                       </td>
                     </tr>
                   );

--- a/src/components/modal/WorkerInfoModal.jsx
+++ b/src/components/modal/WorkerInfoModal.jsx
@@ -1,42 +1,181 @@
-import { isValidElement } from "react";
+import { isValidElement, useEffect, useState } from "react";
 import XIcon from "../../assets/x_icon.svg?react";
 import BasicModal from "./BasicModal";
+import "./modal.css";
+import axiosInstance from "../../api/axiosInstance";
 
-const formattedPhoneNumber = (phoneNumber) => {
-  if (phoneNumber.startsWith("+82")) {
-    return phoneNumber;
-  } else {
-    return "+82" + phoneNumber.slice(-10);
-  }
+const formatPhoneNumber = (value) => {
+  const onlyNums = value.replace(/[^\d]/g, "").slice(0, 11); // 숫자만, 최대 11자리
+
+  if (onlyNums.length < 4) return onlyNums;
+  if (onlyNums.length < 8)
+    return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3)}`;
+  return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3, 7)}-${onlyNums.slice(7)}`;
 };
 
-function ContactTable({ workerInfo }) {
-  const { email, phoneNumber, workerId, isManager } = workerInfo;
+function ContactTable({ workerInfo, onClose }) {
+  const { name, email, phoneNumber, workerId, isManager, selectedZones } =
+    workerInfo;
+  const [formData, setForm] = useState({
+    workerId: workerId,
+    name: name,
+    phoneNumber: phoneNumber,
+    email: email,
+    selectedZones: selectedZones ?? [],
+  });
+
+  const handleInputChange = (field) => (e) => {
+    const value = e.target.value;
+    setForm((prev) => ({
+      ...prev,
+      [field]: field === "phoneNumber" ? formatPhoneNumber(value) : value,
+    }));
+  };
+
+  const handleCheckboxChange = (e, zoneName) => {
+    setForm((prevForm) => {
+      const alreadySelected = prevForm.selectedZones?.includes(zoneName);
+      const updatedZones = alreadySelected
+        ? prevForm.selectedZones.filter((zone) => zone !== zoneName)
+        : [...prevForm.selectedZones, zoneName];
+
+      return {
+        ...prevForm,
+        selectedZones: updatedZones,
+      };
+    });
+  };
+
+  const [zoneList, setZoneList] = useState([]);
+  useEffect(() => {
+    axiosInstance.get(`/api/zones`).then((res) => {
+      setZoneList(res.data.data);
+    });
+  }, []);
+
+  const handleSubmit = () => {
+    let isValid = true;
+    let invalidList = [];
+    const { name, phoneNumber, email } = formData;
+    if (
+      [name, phoneNumber, email].some((val) => val.replace(/\s+/g, "") === "")
+    ) {
+      isValid = false;
+    }
+    const phonePattern = /^\d{3}-\d{4}-\d{4}$/; // 하이픈 포함해서 XXX-YYYY-ZZZZ 형식
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // x@y.z 형식
+    const namePattern = /^[가-힣a-zA-Z\s]+$/; // 이름은 문자여야 함
+    if (!namePattern.test(name)) {
+      isValid = false;
+      invalidList.push("이름");
+    }
+    if (!phonePattern.test(phoneNumber)) {
+      isValid = false;
+      invalidList.push("전화번호");
+    }
+    if (!emailPattern.test(email)) {
+      isValid = false;
+      invalidList.push("이메일");
+    }
+    if (!isValid) {
+      alert(`입력값이 올바른지 확인하세요: ${invalidList.join(", ")}`);
+      return;
+    }
+    if (window.confirm(`수정한 정보를 저장하시겠습니까?`)) {
+      console.log("저장할 정보 전송");
+      axiosInstance
+        .post(`/api/workers/${workerId}`, {
+          name: formData.name,
+          phoneNumber: formData.phoneNumber,
+          email: formData.email,
+          zoneNames: formData.selectedZones,
+        })
+        .then(() => {
+          alert("저장되었습니다!");
+          onClose(True);
+        })
+        .catch((e) => {
+          console.log("저장 실패", e);
+          // onClose(true);
+        });
+    }
+  };
+
   return (
     <div className="table-container">
       <table className="contact-table">
         <thead>
           <tr>
             <th>사번</th>
-            <td>{workerId}</td>
+            <td style={{ backgroundColor: "var(--box-color)" }}>
+              {formData.workerId}
+            </td>
           </tr>
         </thead>
         <tbody>
           <tr>
+            <th scope="row">이름</th>
+            <td>
+              <input
+                onChange={handleInputChange("name")}
+                value={formData.name}
+                className="workerInfo-input"
+              ></input>
+            </td>
+          </tr>
+          <tr>
             <th scope="row">휴대폰 번호</th>
-            <td>{formattedPhoneNumber(phoneNumber)}</td>
+            <td>
+              <input
+                onChange={handleInputChange("phoneNumber")}
+                value={formData.phoneNumber}
+                className="workerInfo-input"
+              ></input>
+            </td>
           </tr>
           <tr>
             <th scope="row">이메일</th>
-            <td>{email}</td>
+            <td>
+              <input
+                onChange={handleInputChange("email")}
+                value={formData.email}
+                className="workerInfo-input"
+              ></input>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">출입 권한 설정</th>
+            <td>
+              <div className="checkbox-group edit-mode">
+                {zoneList.map((z) => {
+                  return (
+                    <span key={z.zoneId}>
+                      <input
+                        id={z.zoneName}
+                        name={z.zoneName}
+                        type="checkbox"
+                        value={z.zoneName}
+                        checked={formData.selectedZones?.includes(z.zoneName)}
+                        onChange={(e) => handleCheckboxChange(e, z.zoneName)}
+                      ></input>
+                      <label htmlFor={z.zoneName}>{z.zoneName}</label>
+                    </span>
+                  );
+                })}
+              </div>
+            </td>
           </tr>
           <tr>
             <th scope="row">담당자 여부</th>
-            <td>{isManager ? "예" : "아니오"}</td>
+            <td style={{ backgroundColor: "var(--box-color)" }}>
+              {isManager ? "예" : "아니오"}
+            </td>
           </tr>
         </tbody>
       </table>
-      <br></br>
+      <div className="button-flex">
+        <button onClick={handleSubmit}>수정</button>
+      </div>
     </div>
   );
 }
@@ -49,8 +188,8 @@ export default function WorkerInfoModal({ isOpen, onClose, workerInfo }) {
         onClose={onClose}
         type="edit"
         modal_contents={{
-          title: `[${workerInfo.name}]의 정보`,
-          contents: <ContactTable workerInfo={workerInfo} />,
+          title: `직원 정보 조회`,
+          contents: <ContactTable workerInfo={workerInfo} onClose={onClose} />,
         }}
       />
     );

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -18,7 +18,7 @@
   height: auto;
   background-color: #fff;
   border-radius: 0.5rem;
-  min-width: 350px;
+  min-width: 35rem;
 }
 
 .modal-close {
@@ -39,10 +39,13 @@
 .modal-box-bottom {
   text-align: center;
   height: auto;
+  max-height: 60vh;
   margin: 1rem 0.5rem;
   display: flex;
   flex-direction: column;
   align-self: center;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 /* 알림창 모달에서 쓰이는 것 */
@@ -74,35 +77,6 @@
   font-size: 1rem;
 }
 
-/* 안 쓰는 것 같은데...? */
-
-/* .modal-contents {
-  margin: 0 1rem 1rem 0;
-  text-align: center;
-  font-weight: bold;
-}
-
-.modal-contents input {
-  padding: 0.5rem;
-  max-width: 30vw;
-}
-
-.modal-contents button {
-  background-color: #7db4fc;
-}
-
-.modal-contents button:hover {
-  background-color: #5ba2ff;
-}
-
-.modal-contents > span {
-  font-size: 1.2rem;
-}
-
-.modal-contents > p {
-  color: #000000;
-} */
-
 .delete-button {
   padding: 0.75rem 1rem;
   font-size: 1rem;
@@ -120,4 +94,27 @@
 .delete-button:active {
   transform: translateY(2px);
   opacity: 1;
+}
+
+/* 작업자 상세조회 모달 */
+.workerInfo-input {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  border: none;
+  text-align: center;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.checkbox-group.edit-mode label {
+  font-size: 1rem !important;
+}
+
+.checkbox-group.edit-mode span {
+  display: flex;
+}
+
+.checkbox-group.edit-mode {
+  margin: 1rem;
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -26,10 +26,6 @@ body {
   font-family: "Noto Sans KR", sans-serif;
 }
 
-h2 {
-  margin-bottom: 0.25rem;
-}
-
 a:hover,
 a:active,
 a:visited {
@@ -762,7 +758,7 @@ strong.normal {
   width: 100%;
   gap: 0.5rem;
   display: flex;
-  justify-content: flex-start;
+  /* justify-content: flex-start; */
   flex-wrap: wrap;
 }
 
@@ -789,7 +785,7 @@ select.search-field {
 
 /* 연락처용 표 */
 .contact-table {
-  width: 80%;
+  width: 100%;
   border-collapse: collapse;
   table-layout: fixed;
 }
@@ -802,7 +798,8 @@ select.search-field {
 }
 
 .contact-table th {
-  background-color: var(--box-color);
+  background-color: var(--blue);
+  color: white;
   width: 40%;
   border-bottom: 1px solid var(--box-color);
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat] 작업자 등록/수정 분리

---

## ✨ 변경 사항
작업자 등록/수정 기능을 분리하기 위한 UI 수정 작업을 진행하였습니다

- API 연동은 아직임
- 입력값 검증
  - (중복 검증은 차후 진행 예정)
  - 전화번호는 XXX-YYYY-ZZZZ 로 받도록 검증하고, 입력할 때 보조할 수 있게 함 (자동으로 - 생성)
  - 이름은 무조건 문자(한글 또는 영어), 사번은 1900~2099 연도 4자리와 임의의 4자리 형태로 고정, 이메일 형식으로

- 작업자 정보 상세보기 모달을, 정보 수정을 위한 모달로 변경하였음
- 포함된 정보/내용 수정
  - 사번, 이름, 휴대폰 번호, 이메일, 출입권한, 담당자 여부를 보여줌
  - 이 중 이름, 휴대폰 번호, 이메일, 출입권한 수정 가능하게끔 변경

---

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/6e2b4f48-5c2a-4e47-8001-f5d3986cc239)
---

## 💬 추가 설명
- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요.
