### PR TITLE
[fix] 공간별 히트맵 센서 아이콘 불일치 해결

### DIFF
--- a/src/pages/Monitoring.jsx
+++ b/src/pages/Monitoring.jsx
@@ -35,9 +35,16 @@ export default function Monitoring() {
           // 예: { "PID-790": {level:2, sensorType:"humid"}, ... }
           statesRes.data.data.map((s) => [s.zoneId, s])
         );
-        const merged = updated.map((z) =>
-          stateMap[z.zoneId] ? { ...z, ...stateMap[z.zoneId] } : z
-        );
+        const merged = updated.map((z) => {
+          const nowState = stateMap[z.zoneId];
+          if (!nowState) return z; // 상태가 없는 zone은 그대로 반환
+          const { sensorType, ...restState } = nowState;
+          return {
+            ...z,
+            ...restState,
+            abnormal_sensor: sensorType, // sensorType을 abnormal_sensor로 변경
+          };
+        });
 
         setZoneList(merged);
         console.log(merged);


### PR DESCRIPTION
## 📌 PR 제목
[fix] 공간별 히트맵 센서 아이콘 불일치 해결

---

## ✨ 변경 사항
- Monitoring.jsx의 zoneList 상태에서 abnormal_sensor: data.sensorType로 백엔드의 response를 수정해서 저장하는 부분을 처음 접속시 zoneList 생성하는 부분에서도 반영하도록 수정

---

## 📸 스크린샷 (선택) - 넣을 예정
| 변경 전 | 변경 후 |
|--------|--------|
| <img width="1710" alt="Screenshot 2025-06-13 at 10 06 45 AM" src="https://github.com/user-attachments/assets/b1ee58ef-8afa-4545-8a00-fe1958b8f7d2" />  | <img width="1710" alt="Screenshot 2025-06-13 at 10 07 19 AM" src="https://github.com/user-attachments/assets/078c073c-b381-4e4c-8046-7ed04ead902a" /> |

---

## ✅ 체크리스트
- [x] 코드에 불필요한 부분은 없는가?
- [x] 기능이 정상 동작하는가?
- [x] 의존성은 문제가 없는가?
- [x] 커밋 메시지는 명확한가?

---

## 📎 관련 이슈
- 관련된 이슈 : https://facto-real.atlassian.net/browse/FRB-230

---

## 💬 추가 설명
- 상태(state)를 잘 확인합시다~
